### PR TITLE
_memoria_matchups minor update

### DIFF
--- a/calculators/_memoria_matchups.php
+++ b/calculators/_memoria_matchups.php
@@ -120,7 +120,7 @@ function _memoria_matchups__main(&$teams) {
             }
         }
     }
-	
+
     $prediction = 0;
     for ($i = 0; $i < $matchup_counter; $i++) {
         $normalised_weight_mult = $matchup_predictions_weight[$i] / $matchup_predictions_weight_total;


### PR DESCRIPTION
- fixed game length multiplier increasing the maximum rating gain for games under 4 minutes instead of decreasing it
- increased starting rating, to both compensate for most likely lower rating gain for high rated players, and to make it harder to hit the bottom for low performing players
- changed matchup weight for uneven games, making the biggest rating difference a bit more significant
- edited variable name & notes